### PR TITLE
Add subprocess call support

### DIFF
--- a/src/para/subprocess/subprocess.cc
+++ b/src/para/subprocess/subprocess.cc
@@ -1,0 +1,88 @@
+// Copyright (c) 2021
+// Authors: Weixiong (Victor) Zheng
+// All rights reserved
+//
+// SPDX-License-Identifier: MIT
+
+#include "para/subprocess/subprocess.h"
+
+#include <sys/wait.h>
+#include <sys/types.h>
+
+namespace para {
+
+void EnvVars::AddVar(std::string&& var) {
+  vars_.push_back(std::forward<std::string>(var));
+}
+
+std::vector<const char*> EnvVars::c_env_vars() const {
+  std::vector<const char*> r;
+  r.push_back(nullptr);
+  for (const std::string& v : vars_) r.push_back(v.c_str());
+  return r;
+}
+
+// See https://linux.die.net/man/2/execve for calling subprocess
+// Watch https://www.youtube.com/watch?v=Mqb2dVRe0uo for pipe handling
+// TODO: Could be nice to have a helper class to handle pipe in RAII way
+Status StartSubprocess(const SubprocessInput& in, SubprocessState* state) {
+  // File descriptors needs to be created before forking
+  int file_descriptors[2];
+  if (pipe(file_descriptors) < 0) {
+    return Status::Error("Failed to opening pipe");
+  }
+  const pid_t child = fork();
+  Status s;
+  if (child < 0) {
+    s.Update(Status::Error("fork() failed"));
+    return s;
+  }
+  if (child == 0) {
+    std::vector<const char*> c_cmd;
+    for (const std::string& arg : in.cmd) c_cmd.push_back(arg.c_str());
+    const std::vector<const char*> c_env_vars = in.envs.c_env_vars();
+    execve(c_cmd[0], const_cast<char* const*>(c_cmd.data()), const_cast<char* const*>(c_env_vars.data()));    
+    // Shouldn't reach the section below if execve succeeds.
+    // close the read fd
+    close(file_descriptors[0]);
+    // get the error message
+    char message[1000];
+    snprintf(message, sizeof(message), "Exec failed %s: %s\n", c_cmd[0], strerror(errno));
+    // write to the pipe and exit
+    ssize_t unused = write(file_descriptors[1], message, strlen(message));
+    close(file_descriptors[1]);
+    _exit(EXIT_FAILURE);
+  } else {
+    state->pid = child;
+    // close write file descriptor
+    close(file_descriptors[1]);
+    char in_buffer[1000];
+    ssize_t n = read(file_descriptors[0], in_buffer, sizeof(in_buffer));
+    if (n > 0) {
+      std::string err_message(in_buffer, n);
+      LOG(ERROR) << "Child process error message: " << err_message;
+      s.Update(Status::Error(std::move(err_message)));
+    }
+    close(file_descriptors[0]);
+  }
+  return s;
+}
+
+Status WaitSubprocess(pid_t pid) {
+  pid_t p;
+  int proc_status;
+  do {
+    p = waitpid(pid, &proc_status, 0);
+  } while (p < 0 && errno == EINTR);
+  if (p < 0) {
+    // TODO: add errno interpretation
+    return Status::Error("waitpid failed");
+  }
+  Status s;
+  if (proc_status != 0) {
+    s.Update(Status::Error("Process failed with status: " + std::to_string(proc_status)));
+  }
+  return s;
+}
+
+}  // namespace para

--- a/src/para/subprocess/subprocess.h
+++ b/src/para/subprocess/subprocess.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2021
+// Authors: Weixiong (Victor) Zheng
+// All rights reserved
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "para/base/status.h"
+#include <unistd.h>
+
+namespace para {
+
+// Class to manage environment building and retrieving
+class EnvVars {
+ public:
+  EnvVars() = default;
+
+  // When the variable is like a flag, add it directly
+  void AddVar(std::string&& var);
+
+  // Add a environment variable pair (key-value)
+  template <typename VarType>
+  void AddVar(const std::string& env_name, const VarType& var) {
+    AddVar(env_name + "=" + std::to_string(var));
+  }
+
+  std::vector<const char*> c_env_vars() const;
+
+ private:
+  std::vector<std::string> vars_;
+};
+
+struct SubprocessInput {
+  std::vector<std::string> cmd;
+  EnvVars envs;
+};
+
+struct SubprocessState {
+  pid_t pid;
+};
+
+Status StartSubprocess(const SubprocessInput& in, SubprocessState* state);
+// Given a pid, wait for it until finished
+Status WaitSubprocess(pid_t pid);
+}  // namespace para

--- a/src/para/subprocess/subprocess_test.cc
+++ b/src/para/subprocess/subprocess_test.cc
@@ -1,0 +1,30 @@
+// Copyright (c) 2021
+// Authors: Weixiong (Victor) Zheng
+// All rights reserved
+//
+// SPDX-License-Identifier: MIT
+
+#include "para/subprocess/subprocess.h"
+#include "para/testing/testing.h"
+
+namespace para {
+
+TEST(Subprocess, StartAndWait) {
+  SubprocessInput in;
+  in.cmd = {"/usr/bin/echo", "happy"};
+  SubprocessState o;
+  ASSERT_OKAY(StartSubprocess(in, &o));
+  ASSERT_OKAY(WaitSubprocess(o.pid));
+}
+
+TEST(Subprocess, NoExistingBinCall) {
+  SubprocessInput in;
+  in.cmd = {"/usr/bin/foo"};
+  SubprocessState o;
+  Status s = StartSubprocess(in, &o);
+  ASSERT_ERROR(s);
+  ASSERT_SUBSTR(s.message(), " Exec failed /usr/bin/foo: No such file or directory");
+}
+
+
+}  // namespace para

--- a/src/para/testing/testing.h
+++ b/src/para/testing/testing.h
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "para/base/status.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 // Macros used in tests
@@ -23,11 +24,25 @@
 #define ASSERT_OKAY(s)                                                         \
   do {                                                                         \
     const para::Status& UNIQUE_ASSERT_OKAY_STATUS = (s);                       \
-    ASSERT_TRUE(UNIQUE_EXPECT_OKAY_STATUS.okay()) << UNIQUE_ASSERT_OKAY_STATUS;\
+    ASSERT_TRUE(UNIQUE_ASSERT_OKAY_STATUS.okay()) << UNIQUE_ASSERT_OKAY_STATUS;\
   } while (false)
 
 #define ASSERT_ERROR(s)                                                           \
   do {                                                                            \
     const para::Status& UNIQUE_ASSERT_ERROR_STATUS = (s);                         \
     EXPECT_FALSE(UNIQUE_ASSERT_ERROR_STATUS.okay()) << UNIQUE_ASSERT_ERROR_STATUS;\
+  } while (false)
+
+#define EXPECT_SUBSTR(test_str, sub_str)                                             \
+  do {                                                                               \
+    const std::string& UNIQUE_EXPECT_TEST_STR = (test_str);                          \
+    const std::string& UNIQUE_EXPECT_SUB_STR = (sub_str);                            \
+    EXPECT_THAT(UNIQUE_EXPECT_TEST_STR, ::testing::HasSubstr(UNIQUE_EXPECT_SUB_STR));\
+  } while (false)
+
+#define ASSERT_SUBSTR(test_str, sub_str)                                             \
+  do {                                                                               \
+    const std::string& UNIQUE_ASSERT_TEST_STR = (test_str);                          \
+    const std::string& UNIQUE_ASSERT_SUB_STR = (sub_str);                            \
+    EXPECT_THAT(UNIQUE_ASSERT_TEST_STR, ::testing::HasSubstr(UNIQUE_ASSERT_SUB_STR));\
   } while (false)


### PR DESCRIPTION
Two functions are provided: StartSubprocess and WaitSubprocess, based on `execve` and `waitpid`. Close #11 